### PR TITLE
Make chatbot::query_chat compute intensive

### DIFF
--- a/crates/chatbot/src/lib.rs
+++ b/crates/chatbot/src/lib.rs
@@ -22,7 +22,7 @@ pub async fn gen_random_number() -> usize {
 ///
 /// Warning: may take a few seconds!
 pub async fn query_chat(messages: &[String]) -> Vec<String> {
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    std::thread::sleep(Duration::from_secs(2));
     let most_recent = messages.last().unwrap();
     vec![
         format!("\"{most_recent}\"? And how does that make you feel?"),

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 [dependencies]
 chatbot = { path = "../chatbot" }
 miniserve = { path = "../miniserve" }
-serde = { version = "1.0.216", features = ["derive"] }
+serde = { version = "1.0.216", features = ["rc", "derive", "std"] }
 serde_json = "1.0.133"
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }


### PR DESCRIPTION
"Improvements" to our "language model" have required it to become more computationally intensive. This is represented by `tokio::time::sleep` (a non-blocking operation) changing into `std::thread::sleep` (a blocking operation).